### PR TITLE
Fix "g++ -std=c++14 -Wall -Werror" errors on Linux with GCC > 5.4.0

### DIFF
--- a/include/connector/omicronConnectorClient.h
+++ b/include/connector/omicronConnectorClient.h
@@ -452,7 +452,11 @@ namespace omicronConnector
 
         static const int ExtraDataSize = 1024;
         unsigned int extraDataType;
+#if !defined(__GNUC__)
         unsigned int extraDataItems;
+#else
+        int extraDataItems; // GCC complains of signed-unsigned comparison
+#endif
         unsigned int extraDataMask;
         unsigned char extraData[ExtraDataSize];
 
@@ -689,7 +693,9 @@ namespace omicronConnector
         if(result > 0)
         {
             int offset = 0;
+#if !defined (__GNUC__) // gcc with Werror does not like unused variables
             int msgLen = result - 1;
+#endif
             char* eventPacket = recvbuf;
 
             EventData ed;


### PR DESCRIPTION
When we include include/connector/omicronConnectorClient.h inside
user code base with the above gcc flags enabled, the compiler throws
out errors. This patch alleviates the issue using gcc macros.