### PR TITLE
fix buffer overflow in Event::setExtraDataString

### DIFF
--- a/include/omicron/Event.h
+++ b/include/omicron/Event.h
@@ -581,8 +581,8 @@ namespace omicron
     inline void Event::setExtraDataString(const String& value)
     {
         oassert(myExtraDataType == ExtraDataString);
-        strcpy((char*)myExtraData, value.c_str());
-        myExtraDataItems = (int)value.size();
+        myExtraDataItems = (int)value.size() > (getExtraDataSize() - 1) ? (getExtraDataSize() - 1) : (int)value.size();
+        strncpy((char*)myExtraData, value.c_str(), myExtraDataItems);
         myExtraData[myExtraDataItems] = '\0';
     }
 


### PR DESCRIPTION
when value.size() > ExtraDataSize strcpy will cause buffer overflow